### PR TITLE
Versioning for l1 and l2 data

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Prerequisites:
 ```
 usage: process-cloudnet.py [-h] [--config-dir /FOO/BAR] [--start YYYY-MM-DD]
                            [--stop YYYY-MM-DD] [--input /FOO/BAR]
-                           [--output /FOO/BAR] [-o] [-k] [-na]
+                           [--output /FOO/BAR] [--new-version] [-na]
                            SITE [SITE ...]
 ```
 
@@ -144,8 +144,7 @@ Optional arguments:
 |       | `--stop`        | `current day - 1 `| Stopping date. |
 |       | `--input`       | from `config/main.ini` | Input folder path. |
 |       | `--output`      | from `config/main.ini` | Output folder path. |
-| `-o`  | `--overwrite`   | `False`             | Overwrite data in existing files. |
-| `-k`  | `--keep_uuid`   | `True`              | Keep ID of old file even if the data is overwritten. |
+|       | `--new-version` | `False`             | Create new version of the files. |
 | `-na`  | `--no-api`     | `False`             | Disable API calls. Useful for testing. |
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 markers =
     first_run
-    second_run
+    append_data
+    new_version
+    append_fail

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    first_run
+    second_run

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -94,7 +94,7 @@ def _process_radar(obj, _):
         rpg_path = obj.build_rpg_path()
         _ = _find_input_file(rpg_path, '*.LV1')
         print("Calibrating rpg-fmcw-94 cloud radar..")
-        uuid = rpg2nc(rpg_path, output_file_temp, obj.site_info, keep_uuid=ARGS.keep_uuid)
+        uuid = rpg2nc(rpg_path, output_file_temp, obj.site_info)
         return output_file_temp, output_file, uuid
     raise NotImplementedError
 
@@ -106,7 +106,7 @@ def _process_lidar(obj, _):
     output_file_temp = _replace_path(output_file, TEMP_DIR.name)
     print(f"Calibrating {obj.config['site']['INSTRUMENTS']['lidar']} lidar..")
     try:
-        uuid = ceilo2nc(input_file, output_file_temp, obj.site_info, keep_uuid=ARGS.keep_uuid)
+        uuid = ceilo2nc(input_file, output_file_temp, obj.site_info)
         return output_file_temp, output_file, uuid
     except RuntimeError as error:
         raise error
@@ -131,7 +131,7 @@ def _process_categorize(obj, processed_files):
     output_file_temp = _replace_path(output_file, TEMP_DIR.name)
     try:
         print("Processing categorize file..")
-        uuid = generate_categorize(input_files, output_file_temp, keep_uuid=ARGS.keep_uuid)
+        uuid = generate_categorize(input_files, output_file_temp)
         return output_file_temp, output_file, uuid
     except RuntimeError as error:
         raise error
@@ -148,7 +148,7 @@ def _process_level2(product, obj, processed_files):
     try:
         print(f"Processing {product} product..")
         fun = getattr(module, f"generate_{product_prefix}")
-        uuid = fun(categorize_file, output_file_temp, keep_uuid=ARGS.keep_uuid)
+        uuid = fun(categorize_file, output_file_temp)
         return output_file_temp, output_file, uuid
     except ValueError:
         raise RuntimeError(f"Something went wrong with {product} processing.")
@@ -217,10 +217,6 @@ if __name__ == "__main__":
                         help='Input folder path. Overrides config/main.ini value.')
     parser.add_argument('--output', type=str, metavar='/FOO/BAR',
                         help='Output folder path. Overrides config/main.ini value.')
-    parser.add_argument('-o', '--overwrite', dest='overwrite', action='store_true',
-                        help='Overwrite data in existing files', default=False)
-    parser.add_argument('-k', '--keep_uuid', dest='keep_uuid', action='store_true',
-                        help='Keep ID of old file even if the data is overwritten', default=True)
     parser.add_argument('-na', '--no-api', dest='no_api', action='store_true',
                         help='Disable API calls. Useful for testing.', default=False)
     parser.add_argument('--new-version', dest='new_version', action='store_true',

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -33,7 +33,7 @@ def main():
     for date in cloudnetpy.utils.date_range(start_date, stop_date):
         date_str = date.strftime("%Y%m%d")
         print('Date: ', date_str)
-        obj = FilePaths(date_str, config, site_info)
+        file_paths = FilePaths(date_str, config, site_info)
 
         processed_files = {
             'lidar': '',
@@ -41,23 +41,21 @@ def main():
             'categorize': ''
         }
         for processing_type in processed_files.keys():
-            process, file_to_append = _choose_how_to_process(processing_type, obj)
-            if process:
-                try:
-                    res = _process_level1(processing_type, obj, processed_files, file_to_append)
-                    processed_files[processing_type] = _archive_file(*res, md_api, file_to_append)
-                except (UncalibratedFileMissing, CalibratedFileMissing, RuntimeError,
-                        ValueError, IndexError, TypeError, NotImplementedError) as error:
-                    print(error)
+            try:
+                file_to_append = _find_volatile_file(processing_type, file_paths)
+                res = _process_level1(processing_type, file_paths, processed_files, file_to_append)
+                processed_files[processing_type] = _archive_file(*res, md_api, file_to_append)
+            except (UncalibratedFileMissing, CalibratedFileMissing, VolatileFileError, RuntimeError,
+                    ValueError, IndexError, TypeError, NotImplementedError) as error:
+                print(error)
 
         for product in PRODUCTS:
-            process, file_to_append = _choose_how_to_process(product, obj)
-            if process:
-                try:
-                    res = _process_level2(product, obj, processed_files, file_to_append)
-                    _ = _archive_file(*res, md_api, file_to_append)
-                except (CategorizeFileMissing, RuntimeError, ValueError, IndexError, TypeError) as error:
-                    print(error)
+            try:
+                file_to_append = _find_volatile_file(product, file_paths)
+                res = _process_level2(product, file_paths, processed_files, file_to_append)
+                _ = _archive_file(*res, md_api, file_to_append)
+            except (CategorizeFileMissing, RuntimeError, ValueError, IndexError, TypeError, VolatileFileError) as error:
+                print(error)
     TEMP_DIR.cleanup()
 
 
@@ -69,45 +67,45 @@ def _process_level1(*args) -> Tuple[str, str, str]:
     return res
 
 
-def _process_radar(obj: FilePaths, _, file_to_append: Union[str, None]) -> Tuple[str, str, str]:
-    output_file_temp, output_file = _build_output_file_names('radar', obj, file_to_append)
-    if obj.config['site']['INSTRUMENTS']['radar'] == 'rpg-fmcw-94':
-        rpg_path = obj.build_rpg_path()
+def _process_radar(file_paths: FilePaths, _, file_to_append: Union[str, None]) -> Tuple[str, str, str]:
+    output_file_temp, output_file = _build_output_file_names('radar', file_paths, file_to_append)
+    if file_paths.config['site']['INSTRUMENTS']['radar'] == 'rpg-fmcw-94':
+        rpg_path = file_paths.build_rpg_path()
         _ = _find_uncalibrated_file(rpg_path, '*.LV1')
-        uuid = rpg2nc(rpg_path, output_file_temp, obj.site_info, keep_uuid=isinstance(file_to_append, str))
+        uuid = rpg2nc(rpg_path, output_file_temp, file_paths.site_info, keep_uuid=isinstance(file_to_append, str))
         return output_file_temp, output_file, uuid
     raise NotImplementedError
 
 
-def _process_lidar(obj: FilePaths, _, file_to_append: Union[str, None]) -> Tuple[str, str, str]:
-    output_file_temp, output_file = _build_output_file_names('lidar', obj, file_to_append)
-    input_path = obj.build_standard_path('uncalibrated', 'lidar')
-    input_file = _find_uncalibrated_file(input_path, f"*{obj.dvec[3:]}*")
-    uuid = ceilo2nc(input_file, output_file_temp, obj.site_info, keep_uuid=isinstance(file_to_append, str))
+def _process_lidar(file_paths: FilePaths, _, file_to_append: Union[str, None]) -> Tuple[str, str, str]:
+    output_file_temp, output_file = _build_output_file_names('lidar', file_paths, file_to_append)
+    input_path = file_paths.build_standard_path('uncalibrated', 'lidar')
+    input_file = _find_uncalibrated_file(input_path, f"*{file_paths.date[3:]}*")
+    uuid = ceilo2nc(input_file, output_file_temp, file_paths.site_info, keep_uuid=isinstance(file_to_append, str))
     return output_file_temp, output_file, uuid
 
 
-def _process_categorize(obj: FilePaths, processed_files: dict,
+def _process_categorize(file_paths: FilePaths, processed_files: dict,
                         file_to_append: Union[str, None]) -> Tuple[str, str, str]:
     input_files = processed_files.copy()
-    input_files['model'] = obj.build_calibrated_file_name('model', makedir=False)
+    input_files['model'] = file_paths.build_calibrated_file_name('model', makedir=False)
     input_files['mwr'] = input_files['radar']
     del input_files['categorize']
     for file in input_files.values():
         if not os.path.isfile(file):
             raise CalibratedFileMissing
-    output_file_temp, output_file = _build_output_file_names('categorize', obj, file_to_append)
+    output_file_temp, output_file = _build_output_file_names('categorize', file_paths, file_to_append)
     uuid = generate_categorize(input_files, output_file_temp, keep_uuid=isinstance(file_to_append, str))
     return output_file_temp, output_file, uuid
 
 
-def _process_level2(product: str, obj: FilePaths, processed_files: dict,
+def _process_level2(product: str, file_paths: FilePaths, processed_files: dict,
                     file_to_append: Union[str, None]) -> Tuple[str, str, str]:
     _print_info(product, file_to_append)
     categorize_file = processed_files['categorize']
     if not os.path.isfile(categorize_file):
         raise CategorizeFileMissing
-    output_file_temp, output_file = _build_output_file_names(product, obj, file_to_append)
+    output_file_temp, output_file = _build_output_file_names(product, file_paths, file_to_append)
     product_prefix = product.split('-')[0]
     module = importlib.import_module(f"cloudnetpy.products.{product_prefix}")
     fun = getattr(module, f"generate_{product_prefix}")
@@ -116,16 +114,35 @@ def _process_level2(product: str, obj: FilePaths, processed_files: dict,
     return output_file_temp, output_file, uuid
 
 
-def _build_output_file_names(cloudnet_file_type: str, obj: FilePaths,
+def _build_output_file_names(cloudnet_file_type: str, file_paths: FilePaths,
                              file_to_append: Union[str, None]) -> Tuple[str, str]:
+    """Creates temporary filename and actual filename (without uuid-suffix).
+
+    Args:
+        cloudnet_file_type (str): E.g. 'radar', 'categorize', 'iwc', etc.
+        file_paths (FilePaths): FilePaths instance.
+        file_to_append (str / None): Existing volatile file to be rewritten.
+
+    Returns:
+        tuple: A two element tuple containing:
+            - output_file_temp (str): Temporary filename. New file is initially written here.
+            - output_file (str): Actual filename we want to have in the end.
+
+    Notes:
+        - In case of a volatile file, we can not write into temp directory. Instead we must
+        overwrite the existing file. We also know the final filename because the name will not change.
+        - In case of a new file version, we first create the file in temp folder (output_file_temp).
+        Then later, we add UUID in filename and finally move the file in the correct folder (output_file).
+
+    """
     if file_to_append:
         output_file_temp = file_to_append
         output_file = file_to_append
     else:
         if cloudnet_file_type == 'categorize' or cloudnet_file_type in PRODUCTS:
-            output_file = obj.build_standard_output_file_name(cloudnet_file_type)
+            output_file = file_paths.build_standard_output_file_name(cloudnet_file_type)
         else:
-            output_file = obj.build_calibrated_file_name(cloudnet_file_type)
+            output_file = file_paths.build_calibrated_file_name(cloudnet_file_type)
         output_file_temp = utils.replace_path(output_file, TEMP_DIR.name)
     return output_file_temp, output_file
 
@@ -133,8 +150,10 @@ def _build_output_file_names(cloudnet_file_type: str, obj: FilePaths,
 def _archive_file(output_file_temp: str, output_file: str, uuid: str, md_api: MetadataApi,
                   file_to_append: Union[str, None]) -> str:
     if file_to_append:
+        # We have only rewritten the existing volatile file (with already correct name):
         output_file = output_file_temp
     else:
+        # We have file in temp folder. Now add uuid-to filename and move to correct folder:
         output_file = _rename_and_move_to_correct_folder(output_file_temp, output_file, uuid)
     if not ARGS.no_api:
         try:
@@ -142,7 +161,7 @@ def _archive_file(output_file_temp: str, output_file: str, uuid: str, md_api: Me
         except HTTPError as error:
             print(error)
             os.remove(output_file)
-            if error.response.status_code != FILE_EXISTS_AND_NOT_CHANGED:
+            if error.response.status_code != FILE_EXISTS_AND_NOT_CHANGED:  # Something badly wrong in the portal
                 raise error
     return output_file
 
@@ -154,24 +173,23 @@ def _rename_and_move_to_correct_folder(temp_filename: str, true_filename: str, u
     return true_filename
 
 
-def _choose_how_to_process(cloudnet_file_type: str, obj: FilePaths) -> Tuple[bool, Union[str, None]]:
-    existing_files = _get_cloudnet_files(cloudnet_file_type, obj)
+def _find_volatile_file(cloudnet_file_type: str, file_paths: FilePaths) -> Union[str, None]:
+    existing_files = _get_cloudnet_files(cloudnet_file_type, file_paths)
     n_files = len(existing_files)
-    process, file_to_append = False, None
-    if ARGS.new_version or n_files == 0:
-        process = True
-    elif not ARGS.new_version and n_files == 1 and utils.is_volatile_file(existing_files[0]):
-        process = True
-        file_to_append = existing_files[0]
-    return process, file_to_append
+    if not ARGS.new_version:
+        if n_files > 1 or (n_files == 1 and not utils.is_volatile_file(existing_files[0])):
+            raise VolatileFileError
+        if n_files == 1 and utils.is_volatile_file(existing_files[0]):
+            return existing_files[0]
+    return None
 
 
-def _get_cloudnet_files(processing_type: str, obj: FilePaths) -> list:
+def _get_cloudnet_files(processing_type: str, file_paths: FilePaths) -> list:
     if processing_type in ('radar', 'lidar'):
-        path = obj.build_standard_path('calibrated', processing_type)
+        path = file_paths.build_standard_path('calibrated', processing_type)
     else:
-        path = obj.build_standard_output_path(processing_type)
-    return utils.list_files(path, f"{obj.dvec}*.nc")
+        path = file_paths.build_standard_output_path(processing_type)
+    return utils.list_files(path, f"{file_paths.date}*.nc")
 
 
 def _find_uncalibrated_file(path: str, pattern: str) -> str:
@@ -187,6 +205,13 @@ def _print_info(cloudnet_file_type: str, file_to_append: Union[str, None]) -> No
     else:
         prefix = 'Creating new'
     print(f"{prefix} {cloudnet_file_type} file.. ", end='')
+
+
+class VolatileFileError(Exception):
+    """Internal exception class."""
+    def __init__(self):
+        self.message = "Can't update a stable file"
+        super().__init__(self.message)
 
 
 class UncalibratedFileMissing(Exception):

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -47,17 +47,18 @@ def main():
                 output_file_temp, output_file, uuid = _process_level1(processing_type, obj, processed_files)
                 output_file = _rename_and_move_to_correct_folder(output_file_temp, output_file, uuid)
                 if not ARGS.no_api:
-                    md_api.put(uuid, output_file)
+                    try:
+                        md_api.put(uuid, output_file)
+                    except HTTPError as error:
+                        print(error)
+                        os.remove(output_file)
+                        if error.response.status_code != FILE_EXISTS_AND_NOT_CHANGED:
+                            raise error
                 processed_files[processing_type] = output_file
             except (UncalibratedFileMissing, CalibratedFileMissing, RuntimeError,
                     ValueError, IndexError, TypeError, NotImplementedError,
                     NotWritableFile) as error:
                 print(error)
-            except HTTPError as error:
-                print(error)
-                os.remove(output_file)
-                if error.response.status_code != FILE_EXISTS_AND_NOT_CHANGED:
-                    raise error
 
         for product in ('classification', 'iwc-Z-T-method', 'lwc-scaled-adiabatic', 'drizzle'):
 

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -60,7 +60,7 @@ def main():
     TEMP_DIR.cleanup()
 
 
-def _process_level1(*args):
+def _process_level1(*args) -> Tuple[str, str, str]:
     module = importlib.import_module(__name__)
     return getattr(module, f"_process_{args[0]}")(*args[1:])
 

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -4,6 +4,7 @@ import os
 import argparse
 import importlib
 import tempfile
+import netCDF4
 import cloudnetpy.utils
 from cloudnetpy.categorize import generate_categorize
 from cloudnetpy.instruments import rpg2nc, ceilo2nc
@@ -161,10 +162,17 @@ def _choose_how_to_process(cloudnet_file_type: str, obj: FilePaths) -> (bool, st
     process, file_to_append = False, None
     if ARGS.new_version or n_files == 0:
         process = True
-    elif not ARGS.new_version and n_files == 1:
+    elif not ARGS.new_version and n_files == 1 and _is_volatile(existing_files[0]):
         process = True
         file_to_append = existing_files[0]
     return process, file_to_append
+
+
+def _is_volatile(filename):
+    nc = netCDF4.Dataset(filename)
+    is_missing_pid = not hasattr(nc, 'pid')
+    nc.close()
+    return is_missing_pid
 
 
 def _find_input_file(path: str, pattern: str) -> str:

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -41,6 +41,9 @@ def main():
         }
 
         for processing_type in processed_files.keys():
+
+            n_files = _count_cloudnet_files(processing_type, obj)
+
             try:
                 output_file_temp, output_file, uuid = _process_level1(processing_type, obj, processed_files)
                 output_file = _rename_and_move_to_correct_folder(output_file_temp, output_file, uuid)
@@ -58,6 +61,9 @@ def main():
                     raise error
 
         for product in ('classification', 'iwc-Z-T-method', 'lwc-scaled-adiabatic', 'drizzle'):
+
+            n_files = _count_cloudnet_files(product, obj)
+
             try:
                 output_file_temp, output_file, uuid = _process_level2(product, obj, processed_files)
                 output_file = _rename_and_move_to_correct_folder(output_file_temp, output_file, uuid)
@@ -73,6 +79,14 @@ def main():
                     raise error
         print(' ')
     TEMP_DIR.cleanup()
+
+
+def _count_cloudnet_files(processing_type, obj):
+    if processing_type in ('radar', 'lidar'):
+        path = obj.build_standard_path('calibrated', processing_type)
+    else:
+        path = obj.build_standard_output_path(processing_type)
+    return process_utils.count_nc_files_for_date(path, obj.dvec)
 
 
 def _rename_and_move_to_correct_folder(temp_filename: str, true_filename: str, uuid: str) -> str:

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -61,8 +61,11 @@ def main():
 
 
 def _process_level1(*args) -> Tuple[str, str, str]:
+    _print_info(args[0], args[3])
     module = importlib.import_module(__name__)
-    return getattr(module, f"_process_{args[0]}")(*args[1:])
+    res = getattr(module, f"_process_{args[0]}")(*args[1:])
+    print("done")
+    return res
 
 
 def _process_radar(obj: FilePaths, _, file_to_append: str or None) -> Tuple[str, str, str]:
@@ -98,6 +101,7 @@ def _process_categorize(obj: FilePaths, processed_files: dict, file_to_append: s
 
 def _process_level2(product: str, obj: FilePaths, processed_files: dict,
                     file_to_append: str or None) -> Tuple[str, str, str]:
+    _print_info(product, file_to_append)
     categorize_file = processed_files['categorize']
     if not os.path.isfile(categorize_file):
         raise CategorizeFileMissing
@@ -106,6 +110,7 @@ def _process_level2(product: str, obj: FilePaths, processed_files: dict,
     module = importlib.import_module(f"cloudnetpy.products.{product_prefix}")
     fun = getattr(module, f"generate_{product_prefix}")
     uuid = fun(categorize_file, output_file_temp, keep_uuid=isinstance(file_to_append, str))
+    print('done')
     return output_file_temp, output_file, uuid
 
 
@@ -170,6 +175,14 @@ def _find_uncalibrated_file(path: str, pattern: str) -> str:
         return utils.find_file(path, pattern)
     except FileNotFoundError:
         raise UncalibratedFileMissing()
+
+
+def _print_info(cloudnet_file_type: str, file_to_append: str) -> None:
+    if file_to_append:
+        prefix = 'Appending to existing volatile'
+    else:
+        prefix = 'Creating new'
+    print(f"{prefix} {cloudnet_file_type} file.. ", end='')
 
 
 class UncalibratedFileMissing(Exception):

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -15,6 +15,7 @@ FILE_EXISTS_AND_NOT_CHANGED = 409
 TEMP_DIR = tempfile.TemporaryDirectory()
 PRODUCTS = ('classification', 'iwc-Z-T-method', 'lwc-scaled-adiabatic', 'drizzle')
 
+
 def main():
     """The main function."""
 
@@ -42,7 +43,7 @@ def main():
             if process:
                 try:
                     res = _process_level1(processing_type, obj, processed_files, file_to_append)
-                    processed_files[processing_type] = _put_to_database(*res, md_api, file_to_append)
+                    processed_files[processing_type] = _put_to_portal(*res, md_api, file_to_append)
                 except (UncalibratedFileMissing, CalibratedFileMissing, RuntimeError,
                         ValueError, IndexError, TypeError, NotImplementedError) as error:
                     print(error)
@@ -52,10 +53,9 @@ def main():
             if process:
                 try:
                     res = _process_level2(product, obj, processed_files, file_to_append)
-                    _ = _put_to_database(*res, md_api, file_to_append)
+                    _ = _put_to_portal(*res, md_api, file_to_append)
                 except (CategorizeFileMissing, RuntimeError, ValueError, IndexError, TypeError) as error:
                     print(error)
-            print(' ')
     TEMP_DIR.cleanup()
 
 
@@ -107,7 +107,7 @@ def _process_level2(product: str, obj: FilePaths, processed_files: dict, file_to
     return output_file_temp, output_file, uuid
 
 
-def _put_to_database(output_file_temp, output_file, uuid, md_api, file_to_append) -> str:
+def _put_to_portal(output_file_temp, output_file, uuid, md_api, file_to_append) -> str:
     if file_to_append:
         output_file = output_file_temp
     else:

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -85,6 +85,8 @@ def _process_radar(obj, _):
             print("Calibrating rpg-fmcw-94 cloud radar..")
             return output_file, rpg2nc(rpg_path, output_file, obj.site_info,
                                        keep_uuid=ARGS.keep_uuid)
+        else:
+            raise NotWritableFile
     raise NotImplementedError
 
 

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -2,6 +2,7 @@
 """Master script for CloudnetPy backward processing."""
 import os
 import argparse
+from typing import Tuple
 import importlib
 import tempfile
 import netCDF4
@@ -65,7 +66,7 @@ def _process_level1(*args):
     return getattr(module, f"_process_{args[0]}")(*args[1:])
 
 
-def _process_radar(obj: FilePaths, _, file_to_append: str or None) -> (str, str, str):
+def _process_radar(obj: FilePaths, _, file_to_append: str or None) -> Tuple[str, str, str]:
     output_file_temp, output_file = _build_output_file_names('radar', obj, file_to_append)
     if obj.config['site']['INSTRUMENTS']['radar'] == 'rpg-fmcw-94':
         rpg_path = obj.build_rpg_path()
@@ -75,7 +76,7 @@ def _process_radar(obj: FilePaths, _, file_to_append: str or None) -> (str, str,
     raise NotImplementedError
 
 
-def _process_lidar(obj: FilePaths, _, file_to_append: str or None) -> (str, str, str):
+def _process_lidar(obj: FilePaths, _, file_to_append: str or None) -> Tuple[str, str, str]:
     output_file_temp, output_file = _build_output_file_names('lidar', obj, file_to_append)
     input_path = obj.build_standard_path('uncalibrated', 'lidar')
     input_file = _find_input_file(input_path, f"*{obj.dvec[3:]}*")
@@ -83,7 +84,7 @@ def _process_lidar(obj: FilePaths, _, file_to_append: str or None) -> (str, str,
     return output_file_temp, output_file, uuid
 
 
-def _process_categorize(obj: FilePaths, processed_files: dict, file_to_append: str or None) -> (str, str, str):
+def _process_categorize(obj: FilePaths, processed_files: dict, file_to_append: str or None) -> Tuple[str, str, str]:
     input_files = processed_files.copy()
     input_files['model'] = obj.build_calibrated_file_name('model', makedir=False)
     input_files['mwr'] = input_files['radar']
@@ -96,7 +97,8 @@ def _process_categorize(obj: FilePaths, processed_files: dict, file_to_append: s
     return output_file_temp, output_file, uuid
 
 
-def _process_level2(product: str, obj: FilePaths, processed_files: dict, file_to_append: str or None) -> (str, str, str):
+def _process_level2(product: str, obj: FilePaths, processed_files: dict,
+                    file_to_append: str or None) -> Tuple[str, str, str]:
     categorize_file = processed_files['categorize']
     if not os.path.isfile(categorize_file):
         raise CategorizeFileMissing
@@ -139,7 +141,7 @@ def _rename_and_move_to_correct_folder(temp_filename: str, true_filename: str, u
     return true_filename
 
 
-def _build_output_file_names(cloudnet_file_type: str, obj: FilePaths, file_to_append: str) -> (str, str):
+def _build_output_file_names(cloudnet_file_type: str, obj: FilePaths, file_to_append: str) -> Tuple[str, str]:
     if file_to_append:
         output_file_temp = file_to_append
         output_file = file_to_append

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -103,7 +103,7 @@ def _process_level2(product: str, obj: FilePaths, processed_files: dict, file_to
     product_prefix = product.split('-')[0]
     module = importlib.import_module(f"cloudnetpy.products.{product_prefix}")
     fun = getattr(module, f"generate_{product_prefix}")
-    uuid = fun(categorize_file, output_file_temp)
+    uuid = fun(categorize_file, output_file_temp, keep_uuid=isinstance(file_to_append, str))
     return output_file_temp, output_file, uuid
 
 

--- a/scripts/process-cloudnet.py
+++ b/scripts/process-cloudnet.py
@@ -211,5 +211,7 @@ if __name__ == "__main__":
                         help='Keep ID of old file even if the data is overwritten', default=True)
     parser.add_argument('-na', '--no-api', dest='no_api', action='store_true',
                         help='Disable API calls. Useful for testing.', default=False)
+    parser.add_argument('--new-version', dest='new_version', action='store_true',
+                        help='Process new version.', default=False)
     ARGS = parser.parse_args()
     main()

--- a/src/data_processing/file_paths.py
+++ b/src/data_processing/file_paths.py
@@ -17,12 +17,15 @@ class FilePaths:
         return self._get_nc_name(folder, identifier)
 
     def build_standard_output_file_name(self, product='categorize', makedir=True):
-        folder_id = 'processed' if product == 'categorize' else 'products'
-        root = self.config['main']['PATH']['output']
-        folder = os.path.join(root, self.site_name, folder_id, product, self._year)
+        folder = self.build_standard_output_path(product)
         if makedir:
             os.makedirs(folder, exist_ok=True)
         return self._get_nc_name(folder, product)
+
+    def build_standard_output_path(self, product='categorize'):
+        folder_id = 'processed' if product == 'categorize' else 'products'
+        root = self.config['main']['PATH']['output']
+        return os.path.join(root, self.site_name, folder_id, product, self._year)
 
     def build_standard_path(self, folder_id, instrument_type):
         direction = 'input' if folder_id == 'uncalibrated' else 'output'

--- a/src/data_processing/file_paths.py
+++ b/src/data_processing/file_paths.py
@@ -1,40 +1,41 @@
 import os
+from typing import Tuple
 
 
 class FilePaths:
-    def __init__(self, dvec, config, site_info):
-        self.site_name = site_info['id']
-        self.dvec = dvec
-        self.config = config
-        self.site_info = site_info
-        self._year = _get_year(self.dvec)
+    def __init__(self, date: str, config: dict, site_info: dict):
+        self.site_name: str = site_info['id']
+        self.date: str = date
+        self.config: dict = config
+        self.site_info: dict = site_info
+        self._year: str = _get_year(self.date)
 
-    def build_calibrated_file_name(self, instrument, makedir=True):
+    def build_calibrated_file_name(self, instrument: str, makedir: bool = True) -> str:
         folder = self.build_standard_path('calibrated', instrument)
         if makedir:
             os.makedirs(folder, exist_ok=True)
         identifier = self.config['site']['INSTRUMENTS'][instrument]
         return self._get_nc_name(folder, identifier)
 
-    def build_standard_output_file_name(self, product='categorize', makedir=True):
+    def build_standard_output_file_name(self, product: str = 'categorize', makedir: bool = True) -> str:
         folder = self.build_standard_output_path(product)
         if makedir:
             os.makedirs(folder, exist_ok=True)
         return self._get_nc_name(folder, product)
 
-    def build_standard_output_path(self, product='categorize'):
+    def build_standard_output_path(self, product: str = 'categorize') -> str:
         folder_id = 'processed' if product == 'categorize' else 'products'
         root = self.config['main']['PATH']['output']
         return os.path.join(root, self.site_name, folder_id, product, self._year)
 
-    def build_standard_path(self, folder_id, instrument_type):
+    def build_standard_path(self, folder_id: str, instrument_type: str) -> str:
         direction = 'input' if folder_id == 'uncalibrated' else 'output'
         root = self.config['main']['PATH'][direction]
         instrument = self.config['site']['INSTRUMENTS'][instrument_type]
         return os.path.join(root, self.site_name, folder_id, instrument, self._year)
 
-    def build_rpg_path(self):
-        year, month, day = _split_date(self.dvec)
+    def build_rpg_path(self) -> str:
+        year, month, day = _split_date(self.date)
         root = self.config['main']['PATH']['input']
         prefix = os.path.join(root, self.site_name, 'uncalibrated', 'rpg-fmcw-94')
         path_option1 = os.path.join(prefix, year, month, day)
@@ -43,30 +44,30 @@ class FilePaths:
             return path_option1
         return path_option2
 
-    def build_mwr_file_name(self):
+    def build_mwr_file_name(self) -> str:
         if self.config['site']['INSTRUMENTS']['mwr'] == '':
             return self.build_calibrated_file_name('radar', makedir=False)
         raise NotImplementedError
 
-    def _get_nc_name(self, folder, identifier):
-        file_name = f"{self.dvec}_{self.site_name}_{identifier}.nc"
+    def _get_nc_name(self, folder: str, identifier: str) -> str:
+        file_name = f"{self.date}_{self.site_name}_{identifier}.nc"
         return os.path.join(folder, file_name)
 
 
-def _split_date(dvec):
-    year = _get_year(dvec)
-    month = _get_month(dvec)
-    day = _get_day(dvec)
+def _split_date(date: str) -> Tuple[str, str, str]:
+    year = _get_year(date)
+    month = _get_month(date)
+    day = _get_day(date)
     return year, month, day
 
 
-def _get_year(dvec):
-    return str(dvec[:4])
+def _get_year(date: str) -> str:
+    return str(date[:4])
 
 
-def _get_month(dvec):
-    return str(dvec[4:6])
+def _get_month(date: str) -> str:
+    return str(date[4:6])
 
 
-def _get_day(dvec):
-    return str(dvec[6:8])
+def _get_day(date: str) -> str:
+    return str(date[6:8])

--- a/src/data_processing/utils.py
+++ b/src/data_processing/utils.py
@@ -5,6 +5,7 @@ import datetime
 import configparser
 import hashlib
 import requests
+import netCDF4
 from cloudnetpy.utils import get_time
 from cloudnetpy.plotting.plot_meta import ATTRIBUTES as ATTR
 
@@ -172,3 +173,16 @@ def add_uuid_to_filename(uuid: str, filename: str) -> str:
     new_filename = f"{folder}{suffix}{extension}"
     os.rename(filename, new_filename)
     return new_filename
+
+
+def is_volatile_file(filename):
+    """Check if nc-file is volatile."""
+    nc = netCDF4.Dataset(filename)
+    is_missing_pid = not hasattr(nc, 'pid')
+    nc.close()
+    return is_missing_pid
+
+
+def replace_path(filename: str, new_path: str) -> str:
+    """Replaces path of file."""
+    return filename.replace(os.path.dirname(filename), new_path)

--- a/src/data_processing/utils.py
+++ b/src/data_processing/utils.py
@@ -170,8 +170,8 @@ def add_hash_to_filename(filename: str, hash_sum: str) -> str:
 def add_uuid_to_filename(uuid: str, filename: str) -> str:
     """Adds uuid suffix to file."""
     suffix = f"_{uuid[:4]}"
-    folder, extension = os.path.splitext(filename)
-    new_filename = f"{folder}{suffix}{extension}"
+    filepath, extension = os.path.splitext(filename)
+    new_filename = f"{filepath}{suffix}{extension}"
     os.rename(filename, new_filename)
     return new_filename
 

--- a/src/data_processing/utils.py
+++ b/src/data_processing/utils.py
@@ -5,12 +5,13 @@ import datetime
 import configparser
 import hashlib
 import requests
+from typing import Tuple
 import netCDF4
 from cloudnetpy.utils import get_time
 from cloudnetpy.plotting.plot_meta import ATTRIBUTES as ATTR
 
 
-def read_site_info(site_name):
+def read_site_info(site_name: str) -> dict:
     """Read site information from Cloudnet http API."""
     url = f"https://altocumulus.fmi.fi/api/sites?developer"
     sites = requests.get(url=url).json()
@@ -21,7 +22,7 @@ def read_site_info(site_name):
             return site
 
 
-def find_file(folder, wildcard):
+def find_file(folder: str, wildcard: str) -> str:
     """Find the first file name matching a wildcard.
 
     Args:
@@ -51,13 +52,13 @@ def list_files(folder: str, pattern: str) -> list:
     return []
 
 
-def date_string_to_date(date_string):
+def date_string_to_date(date_string: str) -> datetime.date:
     """Convert YYYY-MM-DD to Python date."""
     date = [int(x) for x in date_string.split('-')]
     return datetime.date(*date)
 
 
-def get_date_from_past(n, reference_date=None):
+def get_date_from_past(n: int, reference_date: str = None) -> str:
     """Return date N-days ago."""
     reference = reference_date or get_time().split()[0]
     date = date_string_to_date(reference) - datetime.timedelta(n)
@@ -97,11 +98,11 @@ def read_conf(args) -> dict:
     return {'main': main_conf}
 
 
-def str2bool(s):
+def str2bool(s: str) -> bool or str:
     return False if s == 'False' else True if s == 'True' else s
 
 
-def get_fields_for_plot(cloudnet_file_type):
+def get_fields_for_plot(cloudnet_file_type: str) -> Tuple[list, int]:
     """Return list of variables and maximum altitude for Cloudnet quicklooks.
 
     Args:
@@ -137,14 +138,14 @@ def get_fields_for_plot(cloudnet_file_type):
     return fields, max_alt
 
 
-def get_plottable_variables_info(cloudnet_file_type):
+def get_plottable_variables_info(cloudnet_file_type: str) -> dict:
     """Find variable IDs and corresponding human readable names."""
     fields = get_fields_for_plot(cloudnet_file_type)[0]
     return {get_var_id(cloudnet_file_type, field): [f"{ATTR[field].name}", i]
             for i, field in enumerate(fields)}
 
 
-def get_var_id(cloudnet_file_type, field):
+def get_var_id(cloudnet_file_type: str, field: str) -> str:
     """Return identifier for variable / Cloudnet file combination."""
     return f"{cloudnet_file_type}-{field}"
 
@@ -175,7 +176,7 @@ def add_uuid_to_filename(uuid: str, filename: str) -> str:
     return new_filename
 
 
-def is_volatile_file(filename):
+def is_volatile_file(filename: str) -> bool:
     """Check if nc-file is volatile."""
     nc = netCDF4.Dataset(filename)
     is_missing_pid = not hasattr(nc, 'pid')

--- a/src/data_processing/utils.py
+++ b/src/data_processing/utils.py
@@ -7,7 +7,6 @@ import hashlib
 import requests
 from cloudnetpy.utils import get_time
 from cloudnetpy.plotting.plot_meta import ATTRIBUTES as ATTR
-from collections import namedtuple
 
 
 def read_site_info(site_name):
@@ -42,11 +41,11 @@ def find_file(folder, wildcard):
     raise FileNotFoundError(f"No {wildcard} in {folder}")
 
 
-def list_files(folder: str, wildcard: str) -> list:
-    """List files from folder (non-recursively) using a wildcard.
-    If folder does not exist, return empty list."""
+def list_files(folder: str, pattern: str) -> list:
+    """List files from folder (non-recursively) using a pattern that can include wildcard.
+    If folder or suitable files do not exist, return empty list."""
     if os.path.isdir(folder):
-        files = fnmatch.filter(os.listdir(folder), wildcard)
+        files = fnmatch.filter(os.listdir(folder), pattern)
         return [path.join(folder, file) for file in files]
     return []
 

--- a/src/data_processing/utils.py
+++ b/src/data_processing/utils.py
@@ -155,3 +155,10 @@ def add_hash_to_filename(filename: str, hash_sum: str) -> str:
     if len(parts) == 1:
         return f"{filename}-{hash_to_name}"
     return f"{''.join(parts[:-1])}-{hash_to_name}.{parts[-1]}"
+
+
+def count_nc_files_for_date(folder: str, date_str: str) -> int:
+    """Counts number of nc-files for certain date in a folder."""
+    if os.path.isdir(folder):
+        return len(fnmatch.filter(os.listdir(folder), f"{date_str}*.nc"))
+    return 0

--- a/src/data_processing/utils.py
+++ b/src/data_processing/utils.py
@@ -42,6 +42,15 @@ def find_file(folder, wildcard):
     raise FileNotFoundError(f"No {wildcard} in {folder}")
 
 
+def list_files(folder: str, wildcard: str) -> list:
+    """List files from folder (non-recursively) using a wildcard.
+    If folder does not exist, return empty list."""
+    if os.path.isdir(folder):
+        files = fnmatch.filter(os.listdir(folder), wildcard)
+        return [path.join(folder, file) for file in files]
+    return []
+
+
 def date_string_to_date(date_string):
     """Convert YYYY-MM-DD to Python date."""
     date = [int(x) for x in date_string.split('-')]
@@ -155,13 +164,6 @@ def add_hash_to_filename(filename: str, hash_sum: str) -> str:
     if len(parts) == 1:
         return f"{filename}-{hash_to_name}"
     return f"{''.join(parts[:-1])}-{hash_to_name}.{parts[-1]}"
-
-
-def count_nc_files_for_date(folder: str, date_str: str) -> int:
-    """Counts number of nc-files for certain date in a folder."""
-    if os.path.isdir(folder):
-        return len(fnmatch.filter(os.listdir(folder), f"{date_str}*.nc"))
-    return 0
 
 
 def add_uuid_to_filename(uuid: str, filename: str) -> str:

--- a/src/data_processing/utils.py
+++ b/src/data_processing/utils.py
@@ -5,7 +5,7 @@ import datetime
 import configparser
 import hashlib
 import requests
-from typing import Tuple
+from typing import Tuple, Union
 import netCDF4
 from cloudnetpy.utils import get_time
 from cloudnetpy.plotting.plot_meta import ATTRIBUTES as ATTR
@@ -98,7 +98,7 @@ def read_conf(args) -> dict:
     return {'main': main_conf}
 
 
-def str2bool(s: str) -> bool or str:
+def str2bool(s: str) -> Union[bool, str]:
     return False if s == 'False' else True if s == 'True' else s
 
 

--- a/src/data_processing/utils.py
+++ b/src/data_processing/utils.py
@@ -162,3 +162,12 @@ def count_nc_files_for_date(folder: str, date_str: str) -> int:
     if os.path.isdir(folder):
         return len(fnmatch.filter(os.listdir(folder), f"{date_str}*.nc"))
     return 0
+
+
+def add_uuid_to_filename(uuid: str, filename: str) -> str:
+    """Adds uuid suffix to file."""
+    suffix = f"_{uuid[:4]}"
+    folder, extension = os.path.splitext(filename)
+    new_filename = f"{folder}{suffix}{extension}"
+    os.rename(filename, new_filename)
+    return new_filename

--- a/tests/e2e/process_cloudnet/main.py
+++ b/tests/e2e/process_cloudnet/main.py
@@ -30,13 +30,17 @@ def main():
     test_cmd = ['-v', 'tests/e2e/process_cloudnet/tests.py', '--site', site, '--date', start,
                 '--input', input_folder, '--output', output_folder]
 
-    # Process to empty directories
     subprocess.check_call(process_cmd)
     pytest.main(test_cmd + ['-m', 'first_run'])
 
-    # Rewrite existing files and keep uuids
     subprocess.check_call(process_cmd)
-    pytest.main(test_cmd + ['-m', 'second_run'])
+    pytest.main(test_cmd + ['-m', 'append_data'])
+
+    subprocess.check_call(process_cmd + ['--new-version'])
+    pytest.main(test_cmd + ['-m', 'new_version'])
+
+    subprocess.check_call(process_cmd)
+    pytest.main(test_cmd + ['-m', 'append_fail'])
 
     remove_files(f'{lidar_root}/2020')
 

--- a/tests/e2e/process_cloudnet/main.py
+++ b/tests/e2e/process_cloudnet/main.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
 import subprocess
+import shutil
 from os import path
 import argparse
 import pytest
-from test_utils.utils import start_server, remove_dirs, remove_files
+from test_utils.utils import start_server, remove_dirs, remove_files, remove_dir
 
 SCRIPT_PATH = path.dirname(path.realpath(__file__))
+
+
+def _clean_dirs(lidar_root, output_folder, site):
+    remove_files(path.join(lidar_root, '2020'))
+    remove_dirs(path.join(output_folder, site, 'calibrated'), keep='ecmwf')
+    remove_dir(path.join(output_folder, site, 'processed'))
+    remove_dir(path.join(output_folder, site, 'products'))
 
 
 def main():
@@ -16,9 +24,7 @@ def main():
     stop = '2020-04-03'
     lidar_root = path.join(input_folder, site, 'uncalibrated', 'chm15k')
 
-    remove_files(path.join(lidar_root, start[:4]))
-    remove_dirs(path.join(output_folder, site), 'calibrated')
-    remove_dirs(path.join(output_folder, site, 'calibrated'), 'ecmwf')
+    _clean_dirs(lidar_root, output_folder, site)
 
     start_server(5000, 'tests/data/server/metadata', f'{SCRIPT_PATH}/md.log')
 
@@ -42,7 +48,7 @@ def main():
     subprocess.check_call(process_cmd)
     pytest.main(test_cmd + ['-m', 'append_fail'])
 
-    remove_files(f'{lidar_root}/2020')
+    _clean_dirs(lidar_root, output_folder, site)
 
 
 if __name__ == "__main__":

--- a/tests/e2e/process_cloudnet/tests.py
+++ b/tests/e2e/process_cloudnet/tests.py
@@ -5,7 +5,7 @@ from glob import glob
 
 
 @pytest.mark.first_run
-@pytest.mark.second_run
+@pytest.mark.append_data
 class TestCloudnetProcessing:
 
     @pytest.fixture(autouse=True)
@@ -57,6 +57,42 @@ class TestCloudnetProcessing:
             assert _read_file_type(file) == file_type
 
 
+@pytest.mark.new_version
+@pytest.mark.append_fail
+class TestCloudnetProcessingNewVersion:
+
+    @pytest.fixture(autouse=True)
+    def _fetch_params(self, params):
+        self.site = params['site']
+        self.input = params['input']
+        self.output = params['output']
+        self.date = params['date'].replace('-', '')
+        self.year = self.date[:4]
+
+    def test_that_exists_two_calibrated_lidar_files(self):
+        files = glob('/'.join((self.output, self.site, 'calibrated/chm15k',
+                               self.year, f"{self.date}_{self.site}_chm15k_*.nc")))
+        assert len(files) == 2
+
+    def test_that_exists_two_calibrated_radar_files(self):
+        files = glob('/'.join((self.output, self.site, 'calibrated/rpg-fmcw-94',
+                               self.year, f"{self.date}_{self.site}_rpg-fmcw-94_*.nc")))
+        assert len(files) == 2
+
+    def test_that_exists_two_categorize_files(self):
+        files = glob('/'.join((self.output, self.site, 'processed/categorize',
+                               self.year, f"{self.date}_{self.site}_categorize_*.nc")))
+        assert len(files) == 2
+
+    def test_that_exists_two_product_files_each(self):
+        products = ['iwc-Z-T-method', 'lwc-scaled-adiabatic', 'classification']
+        file_types = ['iwc', 'lwc', 'classification', 'drizzle']
+        for product, file_type in zip(products, file_types):
+            files = glob('/'.join((self.output, self.site, f"products/{product}",
+                                   self.year, f"{self.date}_{self.site}_{product}_*.nc")))
+            assert len(files) == 2
+
+
 @pytest.mark.first_run
 def test_that_PUTs_all_files_to_metadata_server():
     n_files = 7
@@ -65,7 +101,7 @@ def test_that_PUTs_all_files_to_metadata_server():
         assert file.read().count('PUT') == n_files
 
 
-@pytest.mark.second_run
+@pytest.mark.append_data
 def test_that_PUTs_identical_files_to_metadata_server():
     lines = []
     script_path = os.path.dirname(os.path.realpath(__file__))
@@ -78,6 +114,22 @@ def test_that_PUTs_identical_files_to_metadata_server():
         second_sub = lines[n+7]
         ind = first_sub.index('PUT')
         assert first_sub[ind:] == second_sub[ind:]
+
+
+@pytest.mark.new_version
+@pytest.mark.append_fail
+def test_that_PUTs_new_files_to_metadata_server():
+    lines = []
+    script_path = os.path.dirname(os.path.realpath(__file__))
+    with open(f'{script_path}/md.log', 'r') as file:
+        for line in file:
+            lines.append(line)
+    assert len(lines) == 21
+    for n in range(7):
+        first_sub = lines[n]
+        third_sub = lines[n+14]
+        ind = first_sub.index('PUT')
+        assert first_sub[ind:] != third_sub[ind:]
 
 
 def _read_file_type(file):

--- a/tests/e2e/process_cloudnet/tests.py
+++ b/tests/e2e/process_cloudnet/tests.py
@@ -102,7 +102,7 @@ def test_that_PUTs_all_files_to_metadata_server():
 
 
 @pytest.mark.append_data
-def test_that_PUTs_identical_files_to_metadata_server():
+def test_that_PUTs_updated_files_to_metadata_server():
     lines = []
     script_path = os.path.dirname(os.path.realpath(__file__))
     with open(f'{script_path}/md.log', 'r') as file:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,3 +14,13 @@ def nc_file(tmpdir_factory):
     root_grp.day = '20'
     root_grp.close()
     return file_name
+
+
+@pytest.fixture(scope='session')
+def nc_file_with_pid(tmpdir_factory):
+    file_name = tmpdir_factory.mktemp("data").join("file_pid.nc")
+    root_grp = netCDF4.Dataset(file_name, "w", format="NETCDF4_CLASSIC")
+    root_grp.createDimension('time', 10)
+    root_grp.pid = 'w20930293029fj3'
+    root_grp.close()
+    return file_name

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -117,3 +117,26 @@ def test_add_uuid_to_filename():
     os.remove(new_filename)
     os.rmdir(temp_dir)
     assert new_filename == f"{filename[:-3]}_abcd.nc"
+
+
+def test_is_volatile_file(nc_file, nc_file_with_pid):
+    assert utils.is_volatile_file(nc_file) is True
+    assert utils.is_volatile_file(nc_file_with_pid) is False
+
+
+def test_replace_path():
+    filename = '/foo/bar/filu.nc'
+    new_path = '/uusi/polku'
+    assert utils.replace_path(filename, new_path) == '/uusi/polku/filu.nc'
+
+
+def test_str2bool():
+    assert utils.str2bool('True') is True
+    assert utils.str2bool('False') is False
+    assert utils.str2bool('kissa') == 'kissa'
+
+
+def test_sha256sum(nc_file):
+    hash_sum = utils.sha256sum(nc_file)
+    assert isinstance(hash_sum, str)
+    assert len(hash_sum) == 64

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,8 @@
+import os
 import datetime
 from pathlib import Path
 from collections import namedtuple
+import tempfile
 import pytest
 import data_processing.utils as utils
 
@@ -86,3 +88,17 @@ def test_read_main_conf():
     args = Args(config_dir=f"{test_file_path}/../../config")
     conf = utils.read_main_conf(args)
     assert 'received_api_files' in conf['PATH']
+
+
+@pytest.mark.parametrize("date, result", [
+    ('20201012', 2),
+    ('20201013', 1),
+    ('20201014', 0),
+])
+def test_count_nc_files_for_date(date, result):
+    f1 = tempfile.TemporaryDirectory(prefix='20201012', suffix='.nc')
+    f2 = tempfile.TemporaryDirectory(prefix='20201012', suffix='.nc')
+    f3 = tempfile.TemporaryDirectory(prefix='20201012', suffix='.txt')
+    f4 = tempfile.TemporaryDirectory(prefix='20201013', suffix='.nc')
+    folder = os.path.dirname(f1.name)
+    assert utils.count_nc_files_for_date(folder, date) == result

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -90,18 +90,20 @@ def test_read_main_conf():
     assert 'received_api_files' in conf['PATH']
 
 
-@pytest.mark.parametrize("date, result", [
-    ('19800112', 2),
-    ('19800113', 1),
-    ('19800114', 0),
+@pytest.mark.parametrize("pattern, result", [
+    ('19800112*.nc', 2),
+    ('19800113*.nc', 1),
+    ('19800114*.nc', 0),
+    ('19800112*.txt', 1),
+    ('19800113*.txt', 0),
 ])
-def test_count_nc_files_for_date(date, result):
+def test_list_files(pattern, result):
     f1 = tempfile.NamedTemporaryFile(prefix='19800112', suffix='.nc')
     f2 = tempfile.NamedTemporaryFile(prefix='19800112', suffix='.nc')
     f3 = tempfile.NamedTemporaryFile(prefix='19800112', suffix='.txt')
     f4 = tempfile.NamedTemporaryFile(prefix='19800113', suffix='.nc')
     folder = os.path.dirname(f1.name)
-    assert utils.count_nc_files_for_date(folder, date) == result
+    assert len(utils.list_files(folder, pattern)) == result
 
 
 def test_add_uuid_to_filename():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -91,14 +91,27 @@ def test_read_main_conf():
 
 
 @pytest.mark.parametrize("date, result", [
-    ('20201012', 2),
-    ('20201013', 1),
-    ('20201014', 0),
+    ('19800112', 2),
+    ('19800113', 1),
+    ('19800114', 0),
 ])
 def test_count_nc_files_for_date(date, result):
-    f1 = tempfile.TemporaryDirectory(prefix='20201012', suffix='.nc')
-    f2 = tempfile.TemporaryDirectory(prefix='20201012', suffix='.nc')
-    f3 = tempfile.TemporaryDirectory(prefix='20201012', suffix='.txt')
-    f4 = tempfile.TemporaryDirectory(prefix='20201013', suffix='.nc')
+    f1 = tempfile.NamedTemporaryFile(prefix='19800112', suffix='.nc')
+    f2 = tempfile.NamedTemporaryFile(prefix='19800112', suffix='.nc')
+    f3 = tempfile.NamedTemporaryFile(prefix='19800112', suffix='.txt')
+    f4 = tempfile.NamedTemporaryFile(prefix='19800113', suffix='.nc')
     folder = os.path.dirname(f1.name)
     assert utils.count_nc_files_for_date(folder, date) == result
+
+
+def test_add_uuid_to_filename():
+    temp_dir = 'tests/data/temp/'
+    filename = 'kukkuu.nc'
+    os.makedirs(temp_dir, exist_ok=True)
+    filename = os.path.join(temp_dir, filename)
+    open(filename, 'a').close()
+    uuid = 'abcdefgh'
+    new_filename = utils.add_uuid_to_filename(uuid, filename)
+    os.remove(new_filename)
+    os.rmdir(temp_dir)
+    assert new_filename == f"{filename[:-3]}_abcd.nc"


### PR DESCRIPTION
This PR allows generation of new file versions by explicitly setting `--new-version` flag when launching the processing script. Otherwise existing (volatile) files are rewritten and their `uuid` is kept. Nothing is done if the directory contains single non-volatile file or multiple files for the processed day / product. New file versions are initially created in a temp directory to avoid collision with existing Cloudnet files that have non-unique file names. 
